### PR TITLE
Add ability to authenticate with a refresh token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+  - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version:
+        - '2.7'
+        - '3.0'
+        - '3.1'
+        rails-version:
+        - '5.2'
+        - '6.0'
+        - '6.1'
+        - '7.0'
+    env:
+      TEST_RAILS_VERSION: ${{ matrix.rails-version }}
+      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+      timeout-minutes: 30
+    - name: Run tests
+      run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ build-iPhoneSimulator/
 # .rubocop-https?--*
 
 Gemfile.lock
+.rspec_status

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
-
 # Specify your gem's dependencies in servicenow-ruby.gemspec
 gemspec
+
+if ENV["TEST_RAILS_VERSION"]
+  gem "activesupport", "~> #{ENV["TEST_RAILS_VERSION"]}.0"
+end

--- a/lib/servicenow.rb
+++ b/lib/servicenow.rb
@@ -2,6 +2,7 @@ require "servicenow/version"
 
 require "active_support"
 require "active_support/core_ext/hash"
+require "active_support/core_ext/module/delegation"
 
 module ServiceNow
   require "servicenow/api"

--- a/lib/servicenow/client.rb
+++ b/lib/servicenow/client.rb
@@ -6,6 +6,26 @@ module ServiceNow
 
     class << self
       def authenticate(instance_id, client_id, client_secret, username, password)
+        authenticate_with_params(instance_id,
+          grant_type: "password",
+          client_id: client_id,
+          client_secret: client_secret,
+          username: username,
+          password: password
+        )
+      end
+
+      def authenticate_with_refresh_token(instance_id, client_id, client_secret, refresh_token)
+        authenticate_with_params(instance_id,
+          grant_type: "refresh_token",
+          client_id: client_id,
+          client_secret: client_secret,
+          refresh_token: refresh_token,
+          scope: "useraccount"
+        )
+      end
+
+      private def authenticate_with_params(instance_id, params)
         connection_options = {
           url: "https://#{instance_id}.service-now.com/"
         }
@@ -16,14 +36,6 @@ module ServiceNow
           faraday.response :raise_error
           faraday.adapter Faraday.default_adapter
         end
-
-        params = {
-          grant_type: "password",
-          client_id: client_id,
-          client_secret: client_secret,
-          username: username,
-          password: password
-        }
 
         response = conn.post('oauth_token.do', params)
         connection = Connection.new(instance_id, response.body["access_token"])

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe ServiceNow::Client do
+  let(:instance_id)   { "instance_id_foo" }
+  let(:client_id)     { "client_id_foo" }
+  let(:client_secret) { "client_secret_foo" }
+  let(:username)      { "some_user" }
+  let(:password)      { "p4ssw0rd" }
+  let(:refresh_token) { "refresh_token_foo" }
+  let(:access_token)  { "access_token_foo" }
+
+  let(:connection)    { double(Faraday) }
+  let(:response)      { double(Faraday::Response, body: {"access_token" => access_token}) }
+
+  describe ".authenticate" do
+    it "connects" do
+      expect(Faraday).to receive(:new).with({url: "https://#{instance_id}.service-now.com/"}).and_return(connection)
+      expect(connection).to receive(:post).with("oauth_token.do",
+        {
+          client_id: client_id,
+          client_secret: client_secret,
+          grant_type: "password",
+          username: username,
+          password: password
+        }
+      ).and_return(response)
+
+      client = described_class.authenticate(instance_id, client_id, client_secret, username, password)
+
+      expect(client).to be_a(described_class)
+      expect(client.connection).to be_a(ServiceNow::Connection)
+      expect(client.connection.headers["Authorization"]).to eq("Bearer #{access_token}")
+    end
+  end
+
+  describe ".authenticate_with_refresh_token" do
+    it "connects" do
+      expect(Faraday).to receive(:new).with({url: "https://#{instance_id}.service-now.com/"}).and_return(connection)
+      expect(connection).to receive(:post).with("oauth_token.do",
+        {
+          client_id: client_id,
+          client_secret: client_secret,
+          grant_type: "refresh_token",
+          refresh_token: refresh_token,
+          scope: "useraccount"
+        }
+      ).and_return(response)
+
+      client = described_class.authenticate_with_refresh_token(instance_id, client_id, client_secret, refresh_token)
+
+      expect(client).to be_a(described_class)
+      expect(client.connection).to be_a(ServiceNow::Connection)
+      expect(client.connection.headers["Authorization"]).to eq("Bearer #{access_token}")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,3 +12,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
+
+require "active_support"
+puts
+puts "\e[93mUsing ActiveSupport #{ActiveSupport.version}\e[0m"


### PR DESCRIPTION
@cbisnett Please review.

Build on top of #5, so I can get CI, so the actual diff is just https://github.com/Fryguy/servicenow-ruby/commit/add_refresh_token_support.  Ci results can be seen here: https://github.com/Fryguy/servicenow-ruby/actions?query=branch%3Aadd_refresh_token_support