### PR TITLE
Add GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+  - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version:
+        - '2.7'
+        - '3.0'
+        - '3.1'
+        rails-version:
+        - '5.2'
+        - '6.0'
+        - '6.1'
+        - '7.0'
+    env:
+      TEST_RAILS_VERSION: ${{ matrix.rails-version }}
+      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+      timeout-minutes: 30
+    - name: Run tests
+      run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ build-iPhoneSimulator/
 # .rubocop-https?--*
 
 Gemfile.lock
+.rspec_status

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
-
 # Specify your gem's dependencies in servicenow-ruby.gemspec
 gemspec
+
+if ENV["TEST_RAILS_VERSION"]
+  gem "activesupport", "~> #{ENV["TEST_RAILS_VERSION"]}.0"
+end

--- a/lib/servicenow.rb
+++ b/lib/servicenow.rb
@@ -2,6 +2,7 @@ require "servicenow/version"
 
 require "active_support"
 require "active_support/core_ext/hash"
+require "active_support/core_ext/module/delegation"
 
 module ServiceNow
   require "servicenow/api"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,3 +12,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
+
+require "active_support"
+puts
+puts "\e[93mUsing ActiveSupport #{ActiveSupport.version}\e[0m"


### PR DESCRIPTION
Additionally fix an issue where the delegation module was not required.

Since GitHub Actions won't run on PRs that introduce them, you can see the results on my branch on my fork: https://github.com/Fryguy/servicenow-ruby/actions/runs/8440596337