### PR TITLE
Upgrade faraday to 1.x

### DIFF
--- a/servicenow-api.gemspec
+++ b/servicenow-api.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "byebug"
 
-  spec.add_dependency "faraday", "< 1.0"
-  spec.add_dependency "faraday_middleware", "< 1.0"
+  spec.add_dependency "faraday", "~> 1.10"
+  spec.add_dependency "faraday_middleware", "~> 1.2"
   spec.add_dependency "activesupport", ">= 5.0"
 end


### PR DESCRIPTION
Faraday 2.x requires some changes, so this at least allows 1.x. This is needed because most projects out there are at least on 1.x, and the <1.0 creates bundler conflicts.